### PR TITLE
Style :focus-visible

### DIFF
--- a/index.html
+++ b/index.html
@@ -253,7 +253,7 @@
             color: #FF6F61; 
         }
 
-        #about-btn:focus-visible, .close-btn:focus-visible {
+        #about-btn:focus-visible, .close-btn:focus-visible, .controls select:focus-visible, .controls button:focus-visible {
             outline: double #000 6px;
             outline-offset: -4px;
             border-color: #FF6F61;

--- a/index.html
+++ b/index.html
@@ -87,10 +87,7 @@
 		}
 
         .slider-container {
-            margin-bottom: 20px;
             display: contents;
-            justify-content: center;
-            align-items: center;
         }
 
 

--- a/index.html
+++ b/index.html
@@ -60,7 +60,7 @@
             transition: all 0.3s ease;
         }
 
-        .controls button:hover, .controls select:focus-within {
+        .controls button:hover, .controls select:focus-within, .controls select:hover {
             background-color: #FF6F61; 
             color: #FFFFFF; 
             border-color: #333333;

--- a/index.html
+++ b/index.html
@@ -81,7 +81,7 @@
 			justify-items: flex-end;
 			justify-content: center;
 			align-items: center;
-			row-gap: 20px;
+			gap: 20px 9px;
 			grid-auto-rows: min-content;
 			padding-bottom: 20px;
 		}
@@ -93,9 +93,6 @@
             align-items: center;
         }
 
-        .slider-label {
-            margin-right: 10px;
-        }
 
         #volume-slider, #tempo-slider, #drum-volume-slider {
             width: 300px;

--- a/index.html
+++ b/index.html
@@ -72,9 +72,20 @@
         }
 
         /* Styles for volume, tempo, and drum volume sliders */
+		[id="volume-container"] {
+			display: grid;
+			grid-template-columns: 17.3ch 300px 8ch;
+			justify-items: flex-end;
+			justify-content: center;
+			align-items: center;
+			row-gap: 20px;
+			grid-auto-rows: min-content;
+			padding-bottom: 20px;
+		}
+
         .slider-container {
             margin-bottom: 20px;
-            display: flex;
+            display: contents;
             justify-content: center;
             align-items: center;
         }

--- a/index.html
+++ b/index.html
@@ -245,10 +245,11 @@
             color: #FF6F61; 
         }
 
-		#about-btn:focus-visible {
-			outline: double #000 6px;
-			outline-offset: -4px;
-		}/* */
+	#about-btn:focus-visible {
+            outline: double #000 6px;
+	    outline-offset: -4px;
+	    border-color: #FF6F61;
+	}
     </style>
 </head>
 <body>

--- a/index.html
+++ b/index.html
@@ -43,9 +43,13 @@
             transform: scale(1.1);
         }
 
-	.key:focus-visible {
+	.key:focus-visible, .drum-pad:focus-visible {
             outline: double #ff6f61 6px;
             outline-offset: -4px;
+	}
+
+	.active.drum-pad:focus-visible {
+	    outline-color: black;
 	}
 
 	.pressed.key:focus-visible {

--- a/index.html
+++ b/index.html
@@ -73,7 +73,7 @@
             transition: all 0.3s ease;
         }
 
-        .controls button:hover, .controls select:focus-within, .controls select:hover {
+        .controls button:hover, .controls button:focus-visible, .controls select:focus-within, .controls select:hover {
             background-color: #FF6F61; 
             color: #FFFFFF; 
             border-color: #333333;
@@ -244,6 +244,11 @@
             background-color: #F0F0F0; 
             color: #FF6F61; 
         }
+
+		#about-btn:focus-visible {
+			outline: double #000 6px;
+			outline-offset: -4px;
+		}/* */
     </style>
 </head>
 <body>

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
             transition: all 0.3s ease;
         }
 
-        .controls button:hover, .controls select:hover {
+        .controls button:hover, .controls select:focus-within {
             background-color: #FF6F61; 
             color: #FFFFFF; 
             border-color: #333333; 

--- a/index.html
+++ b/index.html
@@ -115,7 +115,9 @@
             transition: opacity .2s;
         }
 
-        #volume-slider:hover, #tempo-slider:hover, #drum-volume-slider:hover {
+        #volume-slider:hover, #volume-slider:focus-visible,
+	#tempo-slider:hover, #tempo-slider:focus-visible,
+	#drum-volume-slider:hover, #drum-volume-slider:focus-visible {
             opacity: 1;
         }
 

--- a/index.html
+++ b/index.html
@@ -77,7 +77,7 @@
 		
 		[id="volume-container"] {
 			display: grid;
-			grid-template-columns: 17.3ch 300px 8ch;
+			grid-template-columns: auto auto auto;
 			justify-items: flex-end;
 			justify-content: center;
 			align-items: center;

--- a/index.html
+++ b/index.html
@@ -43,6 +43,15 @@
             transform: scale(1.1);
         }
 
+	.key:focus-visible {
+            outline: double #ff6f61 6px;
+            outline-offset: -4px;
+	}
+
+	.pressed.key:focus-visible {
+            outline: none;
+	}
+
         /* Styles for control buttons and sliders */
         .controls select {
             scrollbar-width: thin;

--- a/index.html
+++ b/index.html
@@ -44,6 +44,10 @@
         }
 
         /* Styles for control buttons and sliders */
+        .controls select {
+            scrollbar-width: thin;
+        } /* @supports not (scrollbar-width: thin){ .controls select::-webkit-scrollbar { width: 9px; } } */
+
         .controls button, .controls select {
             margin: 5px;
             padding: 10px;
@@ -59,7 +63,7 @@
         .controls button:hover, .controls select:focus-within {
             background-color: #FF6F61; 
             color: #FFFFFF; 
-            border-color: #333333; 
+            border-color: #333333;
         }
 
         .controls button.active {

--- a/index.html
+++ b/index.html
@@ -72,6 +72,9 @@
         }
 
         /* Styles for volume, tempo, and drum volume sliders */
+		
+		.value-indicator { justify-self: start; }
+		
 		[id="volume-container"] {
 			display: grid;
 			grid-template-columns: 17.3ch 300px 8ch;
@@ -276,17 +279,17 @@
         <div class="slider-container">
             <label for="volume-slider" class="slider-label">Volume (%)</label>
             <input type="range" id="volume-slider" min="0" max="100" value="50">
-            <span id="volume-value">50%</span>
+            <span class="value-indicator" id="volume-value">50%</span>
         </div>
         <div class="slider-container">
             <label for="tempo-slider" class="slider-label">Tempo (BPM)</label>
             <input type="range" id="tempo-slider" min="30" max="240" value="120">
-            <span id="tempo-value">120 BPM</span>
+            <span class="value-indicator" id="tempo-value">120 BPM</span>
         </div>
         <div class="slider-container">
             <label for="drum-volume-slider" class="slider-label">Drum Volume (%)</label>
             <input type="range" id="drum-volume-slider" min="0" max="100" value="50">
-            <span id="drum-volume-value">50%</span>
+            <span class="value-indicator" id="drum-volume-value">50%</span>
         </div>
     </div>
     <div class="controls">

--- a/index.html
+++ b/index.html
@@ -43,18 +43,19 @@
             transform: scale(1.1);
         }
 
-	.key:focus-visible, .drum-pad:focus-visible {
+    .key:focus-visible, .drum-pad:focus-visible {
             outline: double #ff6f61 6px;
             outline-offset: -4px;
-	}
+    }
 
-	.active.drum-pad:focus-visible {
-	    outline-color: black;
-	}
+    .active.drum-pad:focus-visible {
+        outline-color: black;
+        border-color: #FF6F61;
+    }
 
-	.pressed.key:focus-visible {
+    .pressed.key:focus-visible {
             outline: none;
-	}
+    }
 
         /* Styles for control buttons and sliders */
         .controls select {
@@ -85,19 +86,19 @@
         }
 
         /* Styles for volume, tempo, and drum volume sliders */
-		
-		.value-indicator { justify-self: start; }
-		
-		[id="volume-container"] {
-			display: grid;
-			grid-template-columns: auto auto auto;
-			justify-items: flex-end;
-			justify-content: center;
-			align-items: center;
-			gap: 20px 9px;
-			grid-auto-rows: min-content;
-			padding-bottom: 20px;
-		}
+        
+        .value-indicator { justify-self: start; }
+        
+        [id="volume-container"] {
+            display: grid;
+            grid-template-columns: auto auto auto;
+            justify-items: flex-end;
+            justify-content: center;
+            align-items: center;
+            gap: 20px 9px;
+            grid-auto-rows: min-content;
+            padding-bottom: 20px;
+        }
 
         .slider-container {
             display: contents;
@@ -116,8 +117,8 @@
         }
 
         #volume-slider:hover, #volume-slider:focus-visible,
-	#tempo-slider:hover, #tempo-slider:focus-visible,
-	#drum-volume-slider:hover, #drum-volume-slider:focus-visible {
+        #tempo-slider:hover, #tempo-slider:focus-visible,
+        #drum-volume-slider:hover, #drum-volume-slider:focus-visible {
             opacity: 1;
         }
 
@@ -131,12 +132,17 @@
             border-radius: 10px;
         }
 
+
         #volume-slider::-moz-range-thumb, #tempo-slider::-moz-range-thumb, #drum-volume-slider::-moz-range-thumb {
             width: 20px;
             height: 20px;
             background: #FF6F61; 
             cursor: pointer;
             border-radius: 15px;
+        }
+
+        #volume-slider:focus-visible::-moz-range-thumb, #tempo-slider:focus-visible::-moz-range-thumb, #drum-volume-slider:focus-visible::-moz-range-thumb/*, #tempo-slider::-moz-range-thumb, #drum-volume-slider::-moz-range-thumb*/{
+            border: solid 3px black;
         }
 
         /* Styles for drum pads and progress steps */
@@ -247,11 +253,11 @@
             color: #FF6F61; 
         }
 
-	#about-btn:focus-visible {
+        #about-btn:focus-visible, .close-btn:focus-visible {
             outline: double #000 6px;
-	    outline-offset: -4px;
-	    border-color: #FF6F61;
-	}
+            outline-offset: -4px;
+            border-color: #FF6F61;
+    }
     </style>
 </head>
 <body>


### PR DESCRIPTION
Styles the keyboard navigation focus (:focus-visible).
- sounding buttons: get an outline, to differentiate them from pressed ones
- drum pad: get an outline, and the color varies depending on whether the state is on or off
- the about button has focus-visible, similar to the drum pad
- The sliders get full opacity