### PR TITLE
Recovering the link, and remove this is a fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ This web application is designed to provide a microtonal keyboard interface
 with various equal divisions of the octave (<abbr>EDO</abbr>) and drum machine functionality.
 It allows users to experiment with different microtonal scales and create rhythms using synthesized drum sounds.
 The application is built using the <i>Tone.js library</i> for audio synthesis and manipulation.
-<strong>This is a fork. The original code is developed by Zaher Alkaei.</strong>
+<strong>The original code is developed by Zaher Alkaei.</strong>
 You can find the original author's source code at
 <a rel="canonical">https://github.com/zaheralkaei/themicrotonalkeyboard</a>.</strong>
+
+You can see a demo here https://themicrotonalkeyboard.netlify.app/


### PR DESCRIPTION
Recovering the link, and removing this is a fork. Because it was not supposed to affect the original author's repository. However, the application has become keyboard navigable, so it doesn't make sense to keep it exactly as before.